### PR TITLE
OSN-183: 全25プロパティで無次元0値サポート実装

### DIFF
--- a/examples/test19-1-width-zero-deck.json
+++ b/examples/test19-1-width-zero-deck.json
@@ -1,0 +1,55 @@
+{
+  "type": "deck",
+  "title": "Width Zero Support Test",
+  "slides": [
+    {
+      "type": "slide",
+      "title": "Width Zero Support Test", 
+      "children": [
+        {
+          "type": "frame",
+          "style": {
+            "width": 0,
+            "height": "50px",
+            "backgroundColor": "#ff0000",
+            "borderWidth": "0px",
+            "margin": "10px"
+          },
+          "children": [
+            {
+              "type": "text",
+              "content": "width: 0 frame"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "style": {
+            "width": "100px",
+            "height": "50px", 
+            "backgroundColor": "#00ff00",
+            "borderWidth": "0px",
+            "margin": "10px"
+          },
+          "children": [
+            {
+              "type": "text",
+              "content": "width: 100px frame"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "style": {
+            "width": 0,
+            "height": "30px",
+            "backgroundColor": "#0000ff",
+            "borderWidth": "0px",
+            "margin": "10px"
+          },
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/examples/test19-2-all-zero-deck.json
+++ b/examples/test19-2-all-zero-deck.json
@@ -1,0 +1,45 @@
+{
+  "type": "deck",
+  "title": "All Zero Properties Test",
+  "slides": [
+    {
+      "type": "slide",
+      "title": "All Zero Properties Test", 
+      "children": [
+        {
+          "type": "frame",
+          "style": {
+            "width": 0,
+            "height": 0,
+            "minWidth": 0,
+            "minHeight": 0,
+            "maxWidth": 0,
+            "maxHeight": 0,
+            "margin": 0,
+            "marginTop": 0,
+            "marginRight": 0,
+            "marginBottom": 0,
+            "marginLeft": 0,
+            "padding": 0,
+            "paddingTop": 0,
+            "paddingRight": 0,
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "gap": 0,
+            "rowGap": 0,
+            "columnGap": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0,
+            "borderWidth": 0,
+            "borderRadius": 0,
+            "flexBasis": 0,
+            "backgroundColor": "#ff0000"
+          },
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/jsx/types.ts
+++ b/src/jsx/types.ts
@@ -117,14 +117,14 @@ export interface TableCellProps extends BaseJSXProps {
 export interface ImageProps extends BaseJSXProps {
   src: string;
   alt?: string;
-  width?: number;
+  width?: string | 0; // 0のみ数値として許可、他は単位付き文字列
   height?: number;
   children?: never; // 画像要素は子要素を持たない
 }
 
 export interface SvgProps extends BaseJSXProps {
   content?: string; // contentがない場合はchildren使用
-  width?: number;
+  width?: string | 0; // 0のみ数値として許可、他は単位付き文字列
   height?: number;
   children?: never; // SVG要素は子要素を持たない
 }

--- a/src/jsx/types.ts
+++ b/src/jsx/types.ts
@@ -118,14 +118,14 @@ export interface ImageProps extends BaseJSXProps {
   src: string;
   alt?: string;
   width?: string | 0; // 0のみ数値として許可、他は単位付き文字列
-  height?: number;
+  height?: string | 0; // 0のみ数値として許可、他は単位付き文字列
   children?: never; // 画像要素は子要素を持たない
 }
 
 export interface SvgProps extends BaseJSXProps {
   content?: string; // contentがない場合はchildren使用
   width?: string | 0; // 0のみ数値として許可、他は単位付き文字列
-  height?: number;
+  height?: string | 0; // 0のみ数値として許可、他は単位付き文字列
   children?: never; // SVG要素は子要素を持たない
 }
 

--- a/src/layout/StyleConverter.ts
+++ b/src/layout/StyleConverter.ts
@@ -29,10 +29,7 @@ export class StyleConverter {
     propertyName: string = "property",
   ): string {
     if (typeof value === "number") {
-      console.warn(
-        `⚠️  Unitless values are not supported for ${propertyName}. Use "px", "%", "vw", "vh" units instead. Received: ${value}`,
-      );
-      // フォールバック: px単位として扱う
+      // 数値はpx単位として扱う
       return `${value}px`;
     }
 

--- a/src/layout/YogaLayoutEngine.ts
+++ b/src/layout/YogaLayoutEngine.ts
@@ -405,10 +405,8 @@ export class YogaLayoutEngine {
    */
   private validateCSSUnitForYoga(value: string | number, propertyName: string): string | number {
     if (typeof value === "number") {
-      console.warn(
-        `⚠️  Unitless values are not supported for ${propertyName}. Use "px", "%", "vw", "vh" units instead. Received: ${value}`,
-      );
-      return `${value}px`; // フォールバック
+      // 数値はそのままYogaに渡す（Yogaがpx単位として処理する）
+      return value;
     }
     
     if (typeof value === "string") {

--- a/src/renderer/PPTXRenderer.ts
+++ b/src/renderer/PPTXRenderer.ts
@@ -341,8 +341,8 @@ export class PPTXRenderer {
       height: layoutResult.height, // 実際のレイアウトサイズ（ピクセル）
       backgroundColor: style?.backgroundColor,
       background: style?.background, // グラデーション対応
-      borderRadius: style?.borderRadius, // 既に"8px"形式
-      borderWidth: style?.borderWidth, // "2px"形式のボーダー幅
+      borderRadius: typeof style?.borderRadius === 'number' ? `${style.borderRadius}px` : style?.borderRadius, // 0を"0px"に変換
+      borderWidth: typeof style?.borderWidth === 'number' ? `${style.borderWidth}px` : style?.borderWidth, // 0を"0px"に変換
       borderColor: style?.borderColor, // "#ff0000"形式のボーダー色
       borderStyle: style?.borderStyle, // "solid" | "dashed" | "dotted"
       glassEffect: style?.glassEffect, // ガラス風効果

--- a/src/schemas/slideweave.schema.json
+++ b/src/schemas/slideweave.schema.json
@@ -384,7 +384,7 @@
         "gap": { "$ref": "#/definitions/spacingValue" },
         "rowGap": { "$ref": "#/definitions/spacingValue" },
         "columnGap": { "$ref": "#/definitions/spacingValue" },
-        "width": { "$ref": "#/definitions/dimension" },
+        "width": { "$ref": "#/definitions/dimensionWithZero" },
         "height": { "$ref": "#/definitions/dimension" },
         "minWidth": { "$ref": "#/definitions/dimensionNoPt" },
         "minHeight": { "$ref": "#/definitions/dimensionNoPt" },
@@ -507,6 +507,20 @@
     "dimension": {
       "oneOf": [
         { "type": "number" },
+        { 
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?(px|%|vw|vh|em|rem|pt)$",
+          "description": "サイズ指定。対応単位: px, %, vw, vh, em, rem, pt"
+        }
+      ]
+    },
+    "dimensionWithZero": {
+      "oneOf": [
+        { 
+          "type": "number",
+          "enum": [0],
+          "description": "0のみ許可される数値"
+        },
         { 
           "type": "string",
           "pattern": "^\\d+(\\.\\d+)?(px|%|vw|vh|em|rem|pt)$",

--- a/src/schemas/slideweave.schema.json
+++ b/src/schemas/slideweave.schema.json
@@ -371,25 +371,25 @@
         {
           "type": "object",
           "properties": {
-        "margin": { "$ref": "#/definitions/spacingValue" },
-        "marginTop": { "$ref": "#/definitions/spacingValue" },
-        "marginRight": { "$ref": "#/definitions/spacingValue" },
-        "marginBottom": { "$ref": "#/definitions/spacingValue" },
-        "marginLeft": { "$ref": "#/definitions/spacingValue" },
-        "padding": { "$ref": "#/definitions/spacingValue" },
-        "paddingTop": { "$ref": "#/definitions/spacingValue" },
-        "paddingRight": { "$ref": "#/definitions/spacingValue" },
-        "paddingBottom": { "$ref": "#/definitions/spacingValue" },
-        "paddingLeft": { "$ref": "#/definitions/spacingValue" },
-        "gap": { "$ref": "#/definitions/spacingValue" },
-        "rowGap": { "$ref": "#/definitions/spacingValue" },
-        "columnGap": { "$ref": "#/definitions/spacingValue" },
+        "margin": { "$ref": "#/definitions/spacingValueWithZero" },
+        "marginTop": { "$ref": "#/definitions/spacingValueWithZero" },
+        "marginRight": { "$ref": "#/definitions/spacingValueWithZero" },
+        "marginBottom": { "$ref": "#/definitions/spacingValueWithZero" },
+        "marginLeft": { "$ref": "#/definitions/spacingValueWithZero" },
+        "padding": { "$ref": "#/definitions/spacingValueWithZero" },
+        "paddingTop": { "$ref": "#/definitions/spacingValueWithZero" },
+        "paddingRight": { "$ref": "#/definitions/spacingValueWithZero" },
+        "paddingBottom": { "$ref": "#/definitions/spacingValueWithZero" },
+        "paddingLeft": { "$ref": "#/definitions/spacingValueWithZero" },
+        "gap": { "$ref": "#/definitions/spacingValueWithZero" },
+        "rowGap": { "$ref": "#/definitions/spacingValueWithZero" },
+        "columnGap": { "$ref": "#/definitions/spacingValueWithZero" },
         "width": { "$ref": "#/definitions/dimensionWithZero" },
-        "height": { "$ref": "#/definitions/dimension" },
-        "minWidth": { "$ref": "#/definitions/dimensionNoPt" },
-        "minHeight": { "$ref": "#/definitions/dimensionNoPt" },
-        "maxWidth": { "$ref": "#/definitions/dimensionNoPt" },
-        "maxHeight": { "$ref": "#/definitions/dimensionNoPt" },
+        "height": { "$ref": "#/definitions/dimensionWithZero" },
+        "minWidth": { "$ref": "#/definitions/dimensionNoPtWithZero" },
+        "minHeight": { "$ref": "#/definitions/dimensionNoPtWithZero" },
+        "maxWidth": { "$ref": "#/definitions/dimensionNoPtWithZero" },
+        "maxHeight": { "$ref": "#/definitions/dimensionNoPtWithZero" },
         "flex": { 
           "type": "number",
           "minimum": 0,
@@ -406,7 +406,7 @@
           "description": "flex縮小率。0で縮小しない（例: 0, 1）"
         },
         "flexBasis": { 
-          "$ref": "#/definitions/dimensionNoPt",
+          "$ref": "#/definitions/dimensionNoPtWithZero",
           "description": "flex基準サイズ。対応単位: px, %, em, rem"
         },
         "flexDirection": { 
@@ -437,10 +437,10 @@
           "default": "relative",
           "description": "要素の配置方法。relative（デフォルト）、absolute（絶対配置）、static（フロー配置）"
         },
-        "top": { "$ref": "#/definitions/dimensionNoPt" },
-        "right": { "$ref": "#/definitions/dimensionNoPt" },
-        "bottom": { "$ref": "#/definitions/dimensionNoPt" },
-        "left": { "$ref": "#/definitions/dimensionNoPt" },
+        "top": { "$ref": "#/definitions/dimensionNoPtWithZero" },
+        "right": { "$ref": "#/definitions/dimensionNoPtWithZero" },
+        "bottom": { "$ref": "#/definitions/dimensionNoPtWithZero" },
+        "left": { "$ref": "#/definitions/dimensionNoPtWithZero" },
         "inset": { 
           "type": "string",
           "description": "top, right, bottom, leftの一括指定。1〜4つの値で指定（例: '10px', '10px 20px', '10px 20px 30px 40px'）"
@@ -479,8 +479,8 @@
           "type": "object",
           "properties": {
             "borderColor": { "$ref": "#/definitions/colorValue" },
-            "borderWidth": { "$ref": "#/definitions/pixelValue" },
-            "borderRadius": { "$ref": "#/definitions/pixelValue" },
+            "borderWidth": { "$ref": "#/definitions/pixelValueWithZero" },
+            "borderRadius": { "$ref": "#/definitions/pixelValueWithZero" },
             "borderStyle": { 
               "enum": ["solid", "dashed", "dotted"] 
             },
@@ -496,7 +496,7 @@
           "type": "object",
           "properties": {
             "borderColor": { "$ref": "#/definitions/colorValue" },
-            "borderWidth": { "$ref": "#/definitions/pixelValue" },
+            "borderWidth": { "$ref": "#/definitions/pixelValueWithZero" },
             "borderStyle": { 
               "enum": ["solid", "dashed", "dotted"] 
             }
@@ -538,10 +538,38 @@
         }
       ]
     },
+    "dimensionNoPtWithZero": {
+      "oneOf": [
+        { 
+          "type": "number",
+          "enum": [0],
+          "description": "0のみ許可される数値"
+        },
+        { 
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?(px|%|em|rem)$",
+          "description": "サイズ指定。対応単位: px, %, em, rem (pt, vh, vw不可)"
+        }
+      ]
+    },
     "spacingValue": {
       "type": "string",
       "pattern": "^\\d+(\\.\\d+)?(px|%|vw|vh|em|rem|pt)$",
       "description": "余白指定。対応単位: px, %, vw, vh, em, rem, pt"
+    },
+    "spacingValueWithZero": {
+      "oneOf": [
+        { 
+          "type": "number",
+          "enum": [0],
+          "description": "0のみ許可される数値"
+        },
+        { 
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?(px|%|vw|vh|em|rem|pt)$",
+          "description": "余白指定。対応単位: px, %, vw, vh, em, rem, pt"
+        }
+      ]
     },
     "deckStyle": {
       "type": "object",
@@ -648,6 +676,20 @@
       "type": "string",
       "pattern": "^\\d+(\\.\\d+)?px$",
       "description": "px単位必須の数値（PowerPoint制約）。例: \"10px\", \"2.5px\""
+    },
+    "pixelValueWithZero": {
+      "oneOf": [
+        { 
+          "type": "number",
+          "enum": [0],
+          "description": "0のみ許可される数値"
+        },
+        { 
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?px$",
+          "description": "px単位必須の数値（PowerPoint制約）。例: \"10px\", \"2.5px\""
+        }
+      ]
     },
     "gradientStop": {
       "type": "object",

--- a/src/types/elements.ts
+++ b/src/types/elements.ts
@@ -72,7 +72,7 @@ export interface BaseStyle {
   position?: "relative" | "absolute" | "static";
 
   // Dimensions
-  width?: number | string;
+  width?: string | 0; // 0のみ数値として許可、他は単位付き文字列
   height?: number | string;
   minWidth?: number | string;
   minHeight?: number | string;

--- a/src/types/elements.ts
+++ b/src/types/elements.ts
@@ -50,34 +50,34 @@ export interface TextShadow {
 
 export interface BaseStyle {
   // Spacing
-  margin?: number | string;
-  marginTop?: number | string;
-  marginRight?: number | string;
-  marginBottom?: number | string;
-  marginLeft?: number | string;
-  padding?: number | string;
-  paddingTop?: number | string;
-  paddingRight?: number | string;
-  paddingBottom?: number | string;
-  paddingLeft?: number | string;
-  gap?: number | string;
-  rowGap?: number | string;
-  columnGap?: number | string;
+  margin?: string | 0;
+  marginTop?: string | 0;
+  marginRight?: string | 0;
+  marginBottom?: string | 0;
+  marginLeft?: string | 0;
+  padding?: string | 0;
+  paddingTop?: string | 0;
+  paddingRight?: string | 0;
+  paddingBottom?: string | 0;
+  paddingLeft?: string | 0;
+  gap?: string | 0;
+  rowGap?: string | 0;
+  columnGap?: string | 0;
 
   // Positioning
-  top?: number | string;
-  right?: number | string;
-  bottom?: number | string;
-  left?: number | string;
+  top?: string | 0;
+  right?: string | 0;
+  bottom?: string | 0;
+  left?: string | 0;
   position?: "relative" | "absolute" | "static";
 
   // Dimensions
   width?: string | 0; // 0のみ数値として許可、他は単位付き文字列
-  height?: number | string;
-  minWidth?: number | string;
-  minHeight?: number | string;
-  maxWidth?: number | string;
-  maxHeight?: number | string;
+  height?: string | 0; // 0のみ数値として許可、他は単位付き文字列
+  minWidth?: string | 0;
+  minHeight?: string | 0;
+  maxWidth?: string | 0;
+  maxHeight?: string | 0;
 
   // Flexbox Layout
   flex?: number;
@@ -85,7 +85,7 @@ export interface BaseStyle {
   flexWrap?: "nowrap" | "wrap";
   flexGrow?: number;
   flexShrink?: number;
-  flexBasis?: number | string;
+  flexBasis?: string | 0;
   justifyContent?:
     | "flex-start"
     | "flex-end"
@@ -142,11 +142,11 @@ export interface DeckElement extends BaseElement {
 }
 
 export interface DeckStyle {
-  padding?: number | string;
-  paddingTop?: number | string;
-  paddingRight?: number | string;
-  paddingBottom?: number | string;
-  paddingLeft?: number | string;
+  padding?: string | 0;
+  paddingTop?: string | 0;
+  paddingRight?: string | 0;
+  paddingBottom?: string | 0;
+  paddingLeft?: string | 0;
 }
 
 export interface HeaderElement extends BaseElement {
@@ -170,11 +170,11 @@ export interface SlideElement extends BaseElement {
 }
 
 export interface SlideStyle {
-  padding?: number | string;
-  paddingTop?: number | string;
-  paddingRight?: number | string;
-  paddingBottom?: number | string;
-  paddingLeft?: number | string;
+  padding?: string | 0;
+  paddingTop?: string | 0;
+  paddingRight?: string | 0;
+  paddingBottom?: string | 0;
+  paddingLeft?: string | 0;
 }
 
 export interface SlideBackground {
@@ -189,8 +189,8 @@ export interface ContainerElement extends BaseElement {
 
 export interface FrameStyle extends BaseStyle {
   borderColor?: string; // #RRGGBB format
-  borderWidth?: string; // px unit required
-  borderRadius?: string; // px unit required
+  borderWidth?: string | 0; // px unit required or 0
+  borderRadius?: string | 0; // px unit required or 0
   borderStyle?: "solid" | "dashed" | "dotted";
   glassEffect?: boolean;
   // グラデーション対応
@@ -266,7 +266,7 @@ export type ShapeType = "rectangle" | "circle" | "ellipse";
 
 export interface ShapeStyle extends BaseStyle {
   borderColor?: string; // #RRGGBB format
-  borderWidth?: string; // px unit required
+  borderWidth?: string | 0; // px unit required or 0
   borderStyle?: "solid" | "dashed" | "dotted";
   // グラデーション対応
   background?: Background;


### PR DESCRIPTION
## Summary

全25個のCSS長さプロパティで無次元0値サポートを実装しました。

### 🎯 実装範囲

#### 対応プロパティ(25個)
- **レイアウト系(6)**: width, height, minWidth, minHeight, maxWidth, maxHeight
- **間隔系(11)**: margin, marginTop, marginRight, marginBottom, marginLeft, padding, paddingTop, paddingRight, paddingBottom, paddingLeft, gap, rowGap, columnGap
- **位置系(4)**: top, right, bottom, left  
- **ボーダー系(2)**: borderWidth, borderRadius
- **flexBasis(1)**: flexBasis

### 🔧 技術実装

#### JSONSchema
- 5つの新定義追加: `dimensionWithZero`, `spacingValueWithZero`, `dimensionNoPtWithZero`, `pixelValueWithZero`
- 0のみ数値として許可、他は単位付き文字列

#### TypeScript型定義
- 全プロパティを `string  < /dev/null |  0` に統一
- FrameStyle/ShapeStyle/DeckStyle/SlideStyleも対応

#### 警告システム削除
- ユーザー体験向上のため警告を完全削除
- Yogaライブラリが無次元数値を適切に処理することを確認

#### レンダラー対応
- PPTXRenderer: 0値の適切な文字列変換 (`typeof === 'number' ? '${value}px'`)

### 📋 テストケース

#### test19-1-width-zero-deck.json
- width: 0 + borderWidth: 0の基本テスト

#### test19-2-all-zero-deck.json
- 全25プロパティで0値を設定した包括的テスト
- 警告なしでPPTX生成成功、SVG出力で0値確認済み

### ✅ 受け入れ条件達成

- [x] width: 0の指定を受け入れられること
- [x] 0がレンダラーなどの処理で"0px"として解釈されること
- [x] width以外のプロパティで同様の修正が行われること
- [x] borderWidth: 0を含むテストケースが作成され、pptxが生成されること
- [x] JSXでもwidthで無次元の値として0のみが許容されること

### 🚀 実用的効果

CSSライクな記述が可能になり、直感的なAPI提供:

```json
{
  "style": {
    "margin": 0,          // ✅ 警告なし
    "padding": 0,         // ✅ 警告なし  
    "borderWidth": 0,     // ✅ 警告なし
    "width": "100px"      // ✅ 従来通り
  }
}
```

## Test plan

- [x] 型チェック: `npm run typecheck` エラーなし
- [x] 基本テスト: test19-1-width-zero-deck.json でPPTX生成成功
- [x] 包括テスト: test19-2-all-zero-deck.json で全25プロパティ検証
- [x] SVG検証: `uv run scripts/verify-pptx.py` で0値確認
- [x] 警告削除確認: 無次元0値で警告表示なし

🤖 Generated with [Claude Code](https://claude.ai/code)